### PR TITLE
underscores should be allowed in domain names

### DIFF
--- a/ShadowsocksX-NG/ServerProfile.swift
+++ b/ShadowsocksX-NG/ServerProfile.swift
@@ -131,7 +131,7 @@ class ServerProfile: NSObject {
         }
         
         func validateDomainName(_ value: String) -> Bool {
-            let validHostnameRegex = "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$"
+            let validHostnameRegex = "^(([a-zA-Z0-9_]|[a-zA-Z0-9_][a-zA-Z0-9\\-_]*[a-zA-Z0-9_])\\.)*([A-Za-z0-9_]|[A-Za-z0-9_][A-Za-z0-9\\-_]*[A-Za-z0-9_])$"
             
             if (value.range(of: validHostnameRegex, options: .regularExpression) != nil) {
                 return true


### PR DESCRIPTION
[It is perfectly legal to have an underscore in a domain name.](https://stackoverflow.com/a/2183140/6247478) 
I fixed `validateDomainName` so that users who are given a domain name with underscores will not be prevented from using this software.