### PR TITLE
Avoid conflicts with the original ShadowsocksX-NG

### DIFF
--- a/ShadowsocksX-NG.xcodeproj/project.pbxproj
+++ b/ShadowsocksX-NG.xcodeproj/project.pbxproj
@@ -142,7 +142,7 @@
 		9B07EFA91D048E880052D9DF /* menu_icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = menu_icon.png; sourceTree = "<group>"; };
 		9B07EFAA1D048E880052D9DF /* menu_icon_disabled.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = menu_icon_disabled.png; sourceTree = "<group>"; };
 		9B07EFAB1D048E880052D9DF /* menu_icon_disabled@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "menu_icon_disabled@2x.png"; sourceTree = "<group>"; };
-		9B0BFFE51D0460A70040E62B /* ShadowsocksX-NG.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ShadowsocksX-NG.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9B0BFFE51D0460A70040E62B /* ShadowsocksX-NG-R.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ShadowsocksX-NG-R.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B0BFFE81D0460A70040E62B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9B0BFFEA1D0460A70040E62B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9B0BFFED1D0460A70040E62B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -307,7 +307,7 @@
 		9B0BFFE61D0460A70040E62B /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				9B0BFFE51D0460A70040E62B /* ShadowsocksX-NG.app */,
+				9B0BFFE51D0460A70040E62B /* ShadowsocksX-NG-R.app */,
 				9B0BFFF41D0460A70040E62B /* ShadowsocksX-NGTests.xctest */,
 				9B3FFF441D09CD3B0019A709 /* proxy_conf_helper */,
 			);
@@ -407,9 +407,9 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		9B0BFFE41D0460A70040E62B /* ShadowsocksX-NG */ = {
+		9B0BFFE41D0460A70040E62B /* ShadowsocksX-NG-R */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 9B0B00081D0460A70040E62B /* Build configuration list for PBXNativeTarget "ShadowsocksX-NG" */;
+			buildConfigurationList = 9B0B00081D0460A70040E62B /* Build configuration list for PBXNativeTarget "ShadowsocksX-NG-R" */;
 			buildPhases = (
 				A3C8167BB5EB01FBDE2A08BC /* [CP] Check Pods Manifest.lock */,
 				9B0BFFE11D0460A70040E62B /* Sources */,
@@ -422,9 +422,9 @@
 			dependencies = (
 				9B3FFF531D09E2B30019A709 /* PBXTargetDependency */,
 			);
-			name = "ShadowsocksX-NG";
+			name = "ShadowsocksX-NG-R";
 			productName = "ShadowsocksX-NG";
-			productReference = 9B0BFFE51D0460A70040E62B /* ShadowsocksX-NG.app */;
+			productReference = 9B0BFFE51D0460A70040E62B /* ShadowsocksX-NG-R.app */;
 			productType = "com.apple.product-type.application";
 		};
 		9B0BFFF31D0460A70040E62B /* ShadowsocksX-NGTests */ = {
@@ -505,7 +505,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				9B0BFFE41D0460A70040E62B /* ShadowsocksX-NG */,
+				9B0BFFE41D0460A70040E62B /* ShadowsocksX-NG-R */,
 				9B0BFFF31D0460A70040E62B /* ShadowsocksX-NGTests */,
 				9B3FFF431D09CD3B0019A709 /* proxy_conf_helper */,
 			);
@@ -699,7 +699,7 @@
 /* Begin PBXTargetDependency section */
 		9B0BFFF61D0460A70040E62B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 9B0BFFE41D0460A70040E62B /* ShadowsocksX-NG */;
+			target = 9B0BFFE41D0460A70040E62B /* ShadowsocksX-NG-R */;
 			targetProxy = 9B0BFFF51D0460A70040E62B /* PBXContainerItemProxy */;
 		};
 		9B3FFF531D09E2B30019A709 /* PBXTargetDependency */ = {
@@ -899,7 +899,7 @@
 					"$(PROJECT_DIR)",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.qiuyuzhou.ShadowsocksX-NG";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.qiuyuzhou.ShadowsocksX-NG-R";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "ShadowsocksX-NG/ShadowsocksX-NG-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -930,7 +930,7 @@
 					"$(PROJECT_DIR)",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.qiuyuzhou.ShadowsocksX-NG";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.qiuyuzhou.ShadowsocksX-NG-R";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "ShadowsocksX-NG/ShadowsocksX-NG-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
@@ -990,7 +990,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		9B0B00081D0460A70040E62B /* Build configuration list for PBXNativeTarget "ShadowsocksX-NG" */ = {
+		9B0B00081D0460A70040E62B /* Build configuration list for PBXNativeTarget "ShadowsocksX-NG-R" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				9B0B00091D0460A70040E62B /* Debug */,

--- a/ShadowsocksX-NG.xcodeproj/xcshareddata/xcschemes/ShadowsocksX-NG.xcscheme
+++ b/ShadowsocksX-NG.xcodeproj/xcshareddata/xcschemes/ShadowsocksX-NG.xcscheme
@@ -28,7 +28,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3CB2B8006B2B1ACAF9ADCA1DC82E2290"
+               BlueprintIdentifier = "0C108414EE23FDB4033E3B303978D10C"
                BuildableName = "libBRLOptionParser.a"
                BlueprintName = "BRLOptionParser"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -56,7 +56,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "339CC546E4A1696296EFEDC2FA79ADE0"
+               BlueprintIdentifier = "02486B4ED82798E52430FDA750E7D82D"
                BuildableName = "Pods_ShadowsocksX_NGTests.framework"
                BlueprintName = "Pods-ShadowsocksX-NGTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -70,7 +70,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "05800FAF969AA3CD7F8AEB1C36988B53"
+               BlueprintIdentifier = "BAE42B81A719ACCA70D08EC06B64B500"
                BuildableName = "libPods-proxy_conf_helper.a"
                BlueprintName = "Pods-proxy_conf_helper"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -85,8 +85,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "9B0BFFE41D0460A70040E62B"
-               BuildableName = "ShadowsocksX-NG.app"
-               BlueprintName = "ShadowsocksX-NG"
+               BuildableName = "ShadowsocksX-NG-R.app"
+               BlueprintName = "ShadowsocksX-NG-R"
                ReferencedContainer = "container:ShadowsocksX-NG.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -113,8 +113,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "9B0BFFE41D0460A70040E62B"
-            BuildableName = "ShadowsocksX-NG.app"
-            BlueprintName = "ShadowsocksX-NG"
+            BuildableName = "ShadowsocksX-NG-R.app"
+            BlueprintName = "ShadowsocksX-NG-R"
             ReferencedContainer = "container:ShadowsocksX-NG.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -136,8 +136,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "9B0BFFE41D0460A70040E62B"
-            BuildableName = "ShadowsocksX-NG.app"
-            BlueprintName = "ShadowsocksX-NG"
+            BuildableName = "ShadowsocksX-NG-R.app"
+            BlueprintName = "ShadowsocksX-NG-R"
             ReferencedContainer = "container:ShadowsocksX-NG.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -155,8 +155,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "9B0BFFE41D0460A70040E62B"
-            BuildableName = "ShadowsocksX-NG.app"
-            BlueprintName = "ShadowsocksX-NG"
+            BuildableName = "ShadowsocksX-NG-R.app"
+            BlueprintName = "ShadowsocksX-NG-R"
             ReferencedContainer = "container:ShadowsocksX-NG.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/ShadowsocksX-NG/Base.lproj/MainMenu.xib
+++ b/ShadowsocksX-NG/Base.lproj/MainMenu.xib
@@ -12,7 +12,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="ShadowsocksX_NG" customModuleProvider="target">
+        <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="ShadowsocksX_NG_R" customModuleProvider="target">
             <connections>
                 <outlet property="ACLAutoModeMenuItem" destination="sDG-YV-yuQ" id="kIE-Ua-zvx"/>
                 <outlet property="ACLBackChinaMenuItem" destination="lam-el-r4I" id="O41-Lr-e0h"/>
@@ -50,32 +50,31 @@
                 <menuItem title="Showsocks: On" enabled="NO" id="fzk-mE-CEV">
                     <modifierMask key="keyEquivalentModifierMask"/>
                 </menuItem>
-                <menuItem title="Turn ShadowsocksX On" id="GSu-Tf-StS">
-                    <modifierMask key="keyEquivalentModifierMask"/>
+                <menuItem title="Turn ShadowsocksX On" keyEquivalent="s" id="GSu-Tf-StS">
                     <connections>
                         <action selector="toggleRunning:" target="Voe-Tx-rLC" id="EvE-23-Wiv"/>
                     </connections>
                 </menuItem>
                 <menuItem isSeparatorItem="YES" id="LXP-yK-yQu"/>
-                <menuItem title="Auto Mode By PAC" id="r07-Gu-aEz">
+                <menuItem title="Auto Mode By PAC" keyEquivalent="a" id="r07-Gu-aEz">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="selectPACMode:" target="Voe-Tx-rLC" id="l36-cd-xl7"/>
                     </connections>
                 </menuItem>
-                <menuItem title="White List Mode" id="RvZ-Zn-29U">
+                <menuItem title="White List Mode" keyEquivalent="w" id="RvZ-Zn-29U">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="selectWhiteListMode:" target="Voe-Tx-rLC" id="2Q1-PG-9Yu"/>
                     </connections>
                 </menuItem>
-                <menuItem title="Global Mode" id="Mw3-Jm-eXA">
+                <menuItem title="Global Mode" keyEquivalent="g" id="Mw3-Jm-eXA">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="selectGlobalMode:" target="Voe-Tx-rLC" id="7QH-HB-B2e"/>
                     </connections>
                 </menuItem>
-                <menuItem title="Manual Mode" id="8PR-gs-c5N">
+                <menuItem title="Manual Mode" keyEquivalent="m" id="8PR-gs-c5N">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="selectManualMode:" target="Voe-Tx-rLC" id="Xxb-28-6fi"/>

--- a/ShadowsocksX-NG/LaunchAgentUtils.swift
+++ b/ShadowsocksX-NG/LaunchAgentUtils.swift
@@ -12,8 +12,8 @@ let SS_LOCAL_VERSION = "2.5.6.12.static"
 let PRIVOXY_VERSION = "3.0.26.static"
 let APP_SUPPORT_DIR = "/Library/Application Support/ShadowsocksX-NG-R/"
 let LAUNCH_AGENT_DIR = "/Library/LaunchAgents/"
-let LAUNCH_AGENT_CONF_SSLOCAL_NAME = "com.qiuyuzhou.shadowsocksX-NG.local.plist"
-let LAUNCH_AGENT_CONF_PRIVOXY_NAME = "com.qiuyuzhou.shadowsocksX-NG.http.plist"
+let LAUNCH_AGENT_CONF_SSLOCAL_NAME = "com.qiuyuzhou.shadowsocksX-NG-R.local.plist"
+let LAUNCH_AGENT_CONF_PRIVOXY_NAME = "com.qiuyuzhou.shadowsocksX-NG-R.http.plist"
 
 
 func getFileSHA1Sum(_ filepath: String) -> String {
@@ -64,7 +64,7 @@ func generateSSLocalLauchAgentPlist() -> Bool {
     
     // For a complete listing of the keys, see the launchd.plist manual page.
     let dict: NSMutableDictionary = [
-        "Label": "com.qiuyuzhou.shadowsocksX-NG.local",
+        "Label": "com.qiuyuzhou.shadowsocksX-NG-R.local",
         "WorkingDirectory": NSHomeDirectory() + APP_SUPPORT_DIR,
         "KeepAlive": true,
         "StandardOutPath": logFilePath,
@@ -205,7 +205,7 @@ func generatePrivoxyLauchAgentPlist() -> Bool {
     
     // For a complete listing of the keys, see the launchd.plist manual page.
     let dict: NSMutableDictionary = [
-        "Label": "com.qiuyuzhou.shadowsocksX-NG.http",
+        "Label": "com.qiuyuzhou.shadowsocksX-NG-R.http",
         "WorkingDirectory": NSHomeDirectory() + APP_SUPPORT_DIR,
         "KeepAlive": true,
         "StandardOutPath": logFilePath,

--- a/ShadowsocksX-NG/LaunchAgentUtils.swift
+++ b/ShadowsocksX-NG/LaunchAgentUtils.swift
@@ -10,7 +10,7 @@ import Foundation
 
 let SS_LOCAL_VERSION = "2.5.6.12.static"
 let PRIVOXY_VERSION = "3.0.26.static"
-let APP_SUPPORT_DIR = "/Library/Application Support/ShadowsocksX-NG/"
+let APP_SUPPORT_DIR = "/Library/Application Support/ShadowsocksX-NG-R/"
 let LAUNCH_AGENT_DIR = "/Library/LaunchAgents/"
 let LAUNCH_AGENT_CONF_SSLOCAL_NAME = "com.qiuyuzhou.shadowsocksX-NG.local.plist"
 let LAUNCH_AGENT_CONF_PRIVOXY_NAME = "com.qiuyuzhou.shadowsocksX-NG.http.plist"

--- a/ShadowsocksX-NG/ProxyConfHelper.m
+++ b/ShadowsocksX-NG/ProxyConfHelper.m
@@ -9,7 +9,7 @@
 #import "ProxyConfHelper.h"
 #import "proxy_conf_helper_version.h"
 
-#define kShadowsocksHelper @"/Library/Application Support/ShadowsocksX-NG/proxy_conf_helper"
+#define kShadowsocksHelper @"/Library/Application Support/ShadowsocksX-NG-R/proxy_conf_helper"
 
 @implementation ProxyConfHelper
 

--- a/ShadowsocksX-NG/install_helper.sh
+++ b/ShadowsocksX-NG/install_helper.sh
@@ -6,9 +6,9 @@
 #  Created by clowwindy on 14-3-15.
 
 cd `dirname "${BASH_SOURCE[0]}"`
-sudo mkdir -p "/Library/Application Support/ShadowsocksX-NG/"
-sudo cp proxy_conf_helper "/Library/Application Support/ShadowsocksX-NG/"
-sudo chown root:admin "/Library/Application Support/ShadowsocksX-NG/proxy_conf_helper"
-sudo chmod +s "/Library/Application Support/ShadowsocksX-NG/proxy_conf_helper"
+sudo mkdir -p "/Library/Application Support/ShadowsocksX-NG-R/"
+sudo cp proxy_conf_helper "/Library/Application Support/ShadowsocksX-NG-R/"
+sudo chown root:admin "/Library/Application Support/ShadowsocksX-NG-R/proxy_conf_helper"
+sudo chmod +s "/Library/Application Support/ShadowsocksX-NG-R/proxy_conf_helper"
 
 echo done

--- a/ShadowsocksX-NG/install_privoxy.sh
+++ b/ShadowsocksX-NG/install_privoxy.sh
@@ -9,9 +9,9 @@
 
 cd `dirname "${BASH_SOURCE[0]}"`
 privoxyVersion=3.0.26.static
-mkdir -p "$HOME/Library/Application Support/ShadowsocksX-NG/privoxy-$privoxyVersion"
-cp -f privoxy "$HOME/Library/Application Support/ShadowsocksX-NG/privoxy-$privoxyVersion/"
-rm -f "$HOME/Library/Application Support/ShadowsocksX-NG/privoxy"
-ln -s "$HOME/Library/Application Support/ShadowsocksX-NG/privoxy-$privoxyVersion/privoxy" "$HOME/Library/Application Support/ShadowsocksX-NG/privoxy"
+mkdir -p "$HOME/Library/Application Support/ShadowsocksX-NG-R/privoxy-$privoxyVersion"
+cp -f privoxy "$HOME/Library/Application Support/ShadowsocksX-NG-R/privoxy-$privoxyVersion/"
+rm -f "$HOME/Library/Application Support/ShadowsocksX-NG-R/privoxy"
+ln -s "$HOME/Library/Application Support/ShadowsocksX-NG-R/privoxy-$privoxyVersion/privoxy" "$HOME/Library/Application Support/ShadowsocksX-NG-R/privoxy"
 
 echo done

--- a/ShadowsocksX-NG/install_ss_local.sh
+++ b/ShadowsocksX-NG/install_ss_local.sh
@@ -9,11 +9,11 @@
 
 cd `dirname "${BASH_SOURCE[0]}"`
 ssLocalVersion=2.5.6.12.static
-mkdir -p "$HOME/Library/Application Support/ShadowsocksX-NG/ss-local-$ssLocalVersion"
-cp -f ss-local "$HOME/Library/Application Support/ShadowsocksX-NG/ss-local-$ssLocalVersion/"
-rm -f "$HOME/Library/Application Support/ShadowsocksX-NG/ss-local"
-ln -s "$HOME/Library/Application Support/ShadowsocksX-NG/ss-local-$ssLocalVersion/ss-local" "$HOME/Library/Application Support/ShadowsocksX-NG/ss-local"
+mkdir -p "$HOME/Library/Application Support/ShadowsocksX-NG-R/ss-local-$ssLocalVersion"
+cp -f ss-local "$HOME/Library/Application Support/ShadowsocksX-NG-R/ss-local-$ssLocalVersion/"
+rm -f "$HOME/Library/Application Support/ShadowsocksX-NG-R/ss-local"
+ln -s "$HOME/Library/Application Support/ShadowsocksX-NG-R/ss-local-$ssLocalVersion/ss-local" "$HOME/Library/Application Support/ShadowsocksX-NG-R/ss-local"
 
-cp -f libcrypto.1.0.0.dylib "$HOME/Library/Application Support/ShadowsocksX-NG/"
+cp -f libcrypto.1.0.0.dylib "$HOME/Library/Application Support/ShadowsocksX-NG-R/"
 
 echo done

--- a/ShadowsocksX-NG/reload_conf_privoxy.sh
+++ b/ShadowsocksX-NG/reload_conf_privoxy.sh
@@ -6,7 +6,7 @@
 #  Created by 王晨 on 16/10/7.
 #  Copyright © 2016年 zhfish. All rights reserved.
 
-#launchctl kill SIGHUP "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.http.plist"
+#launchctl kill SIGHUP "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG-R.http.plist"
 
-launchctl unload "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.http.plist"
-launchctl load "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.http.plist"
+launchctl unload "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG-R.http.plist"
+launchctl load "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG-R.http.plist"

--- a/ShadowsocksX-NG/reload_conf_ss_local.sh
+++ b/ShadowsocksX-NG/reload_conf_ss_local.sh
@@ -6,7 +6,7 @@
 #  Created by 邱宇舟 on 16/6/6.
 #  Copyright © 2016年 qiuyuzhou. All rights reserved.
 
-#launchctl kill SIGHUP "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.local.plist"
+#launchctl kill SIGHUP "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG-R.local.plist"
 
-launchctl unload "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.local.plist"
-launchctl load "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.local.plist"
+launchctl unload "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG-R.local.plist"
+launchctl load "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG-R.local.plist"

--- a/ShadowsocksX-NG/start_privoxy.sh
+++ b/ShadowsocksX-NG/start_privoxy.sh
@@ -6,4 +6,4 @@
 #  Created by 王晨 on 16/10/7.
 #  Copyright © 2016年 zhfish. All rights reserved.
 
-launchctl load "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.http.plist"
+launchctl load "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG-R.http.plist"

--- a/ShadowsocksX-NG/start_ss_local.sh
+++ b/ShadowsocksX-NG/start_ss_local.sh
@@ -6,4 +6,4 @@
 #  Created by 邱宇舟 on 16/6/6.
 #  Copyright © 2016年 qiuyuzhou. All rights reserved.
 
-launchctl load "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.local.plist"
+launchctl load "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG-R.local.plist"

--- a/ShadowsocksX-NG/stop_privoxy.sh
+++ b/ShadowsocksX-NG/stop_privoxy.sh
@@ -8,4 +8,4 @@
 
 
 
-launchctl unload "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.http.plist"
+launchctl unload "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG-R.http.plist"

--- a/ShadowsocksX-NG/stop_ss_local.sh
+++ b/ShadowsocksX-NG/stop_ss_local.sh
@@ -8,4 +8,4 @@
 
 
 
-launchctl unload "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG.local.plist"
+launchctl unload "$HOME/Library/LaunchAgents/com.qiuyuzhou.shadowsocksX-NG-R.local.plist"


### PR DESCRIPTION
Now you can run ShadowsocksX-NG-R and ShadowsocksX-NG on same machine, without worry they mess up each other:

- macOS won't repeatedly ask your password if you use both app.
- NG-R won't break NG's server preferences when the later have SIP003 plugin options.

You can even safely run NG and NG-R the same time, as long as you only turn on one of them.

Also added some convenient shortcuts for main menu, these shortcuts can be used when main menu activated.

- Toggle Shadowsocks On/Off with `⌘S`. This is an alternative way if you don't want to use the existing global shortcut.
- Toggle Auto/Global/Manual Mode with `A`, `G`, `M`.
